### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-agreeable-smoke-013454910.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-smoke-013454910.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')


### PR DESCRIPTION
Potential fix for [https://github.com/RaviAkhouri30/Resume3.0/security/code-scanning/15](https://github.com/RaviAkhouri30/Resume3.0/security/code-scanning/15)

Add an explicit `permissions` block to this workflow so `GITHUB_TOKEN` is constrained. The safest minimal fix without changing behavior is to set workflow-level read-only access for repository contents.

In `.github/workflows/azure-static-web-apps-agreeable-smoke-013454910.yml`, insert at the workflow root (after `on:` block and before `jobs:`):

- `permissions:`
  - `contents: read`

This preserves existing workflow logic and action steps while ensuring token permissions are explicitly limited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
